### PR TITLE
Updated from every 5 minutes to every 6 hours to run auto-shutdown script.

### DIFF
--- a/.github/workflows/auto_shutdown.yml
+++ b/.github/workflows/auto_shutdown.yml
@@ -2,7 +2,7 @@ name: Auto Shutdown EC2
 
 on:
   schedule:
-    - cron: "*/5 * * * *"  # Every 6 hours
+    - cron: "0 */6 * * *"  # Every 6 hours
   workflow_dispatch:       # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
As title says, and I should save extra unnecessary charge from running too many GitHub Actions workflow jobs.