### PR TITLE
Issue 40 LLM Inference API Deployment Toolkit (AWS EC2/ECS, IaC + Ansible + CI/CD)

### DIFF
--- a/.github/workflows/iac-plan.yml
+++ b/.github/workflows/iac-plan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Plan (EC2)
         working-directory: tofu/ec2
         env:
-          TF_VAR_admin_cidr: ${{ secrets.ADMIN_CIDR }} # sets var.admin_cidr
+          TF_VAR_admin_cidr: ${{ vars.ADMIN_CIDR }} # sets var.admin_cidr
         run: |
           tofu init -backend-config=../backend/ec2.hcl
           tofu plan -no-color

--- a/.github/workflows/iac-plan.yml
+++ b/.github/workflows/iac-plan.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Plan (EC2)
         working-directory: tofu/ec2
+        env:
+          TF_VAR_admin_cidr: ${{ secrets.ADMIN_CIDR }} # sets var.admin_cidr
         run: |
           tofu init -backend-config=../backend/ec2.hcl
           tofu plan -no-color

--- a/ansible/deploy_llm_stack.yml
+++ b/ansible/deploy_llm_stack.yml
@@ -1,0 +1,9 @@
+---
+- hosts: dev
+  become: true
+  roles:
+    - common
+    - ollama
+    - llm_api
+    - prometheus
+    - grafana

--- a/ansible/deploy_llm_stack.yml
+++ b/ansible/deploy_llm_stack.yml
@@ -1,4 +1,5 @@
 ---
+- name: Deploy LLM Infer API server and its stack to EC2
 - hosts: dev
   become: true
   roles:

--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -1,0 +1,1 @@
+openai_api_key: "YOUR_OPENAI_API_KEY_HERE"

--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -1,1 +1,2 @@
-openai_api_key: "YOUR_OPENAI_API_KEY_HERE"
+---
+openai_api_key: ""

--- a/ansible/group_vars/llm_ec2.yml
+++ b/ansible/group_vars/llm_ec2.yml
@@ -1,0 +1,11 @@
+openai_api_key: "YOUR_OPENAI_API_KEY_HERE"
+llm_docker_network: "llmnet"
+llm_api_image: "aws-ec2-utils/llm-api-server:latest"
+ollama_image: "ollama/ollama:latest"
+prometheus_image: "prom/prometheus:latest"
+grafana_image: "grafana/grafana:latest"
+
+expose_llm_api_port: "8000"
+expose_ollama_port: "11434"
+expose_prom_port: "9090"
+expose_grafana_port: "3000"

--- a/ansible/group_vars/llm_ec2.yml
+++ b/ansible/group_vars/llm_ec2.yml
@@ -1,6 +1,5 @@
-openai_api_key: "YOUR_OPENAI_API_KEY_HERE"
+---
 llm_docker_network: "llmnet"
-llm_api_image: "aws-ec2-utils/llm-api-server:latest"
 ollama_image: "ollama/ollama:latest"
 prometheus_image: "prom/prometheus:latest"
 grafana_image: "grafana/grafana:latest"
@@ -9,3 +8,13 @@ expose_llm_api_port: "8000"
 expose_ollama_port: "11434"
 expose_prom_port: "9090"
 expose_grafana_port: "3000"
+
+llm_api_image: "581649156172.dkr.ecr.ca-central-1.amazonaws.com/aws-ec2-utils/llm-api-server:latest"
+ollama_host: "http://ollama:11434"
+openai_api_key: ""
+
+# ECR
+ecr_registry: "581649156172.dkr.ecr.ca-central-1.amazonaws.com"
+ecr_region: "ca-central-1"
+
+expose_prometheus_port: "9090"

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,2 @@
 [dev]
-52.60.198.88 ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/aws-canada-backend-1.pem
+3.99.161.157 ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/aws-canada-backend-1.pem

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for roles/common
+llm_docker_network: llmnet

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 # defaults file for roles/common
-llm_docker_network: llmnet

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -33,3 +33,13 @@
         name: docker
         enabled: true
         state: started
+
+#- name: Ensure docker SDK for Python is present
+#  ansible.builtin.pip:
+#    name: docker
+#  become: true
+
+- name: Create shared docker network
+  community.docker.docker_network:
+    name: "{{ llm_docker_network }}"
+    state: present

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -34,11 +34,6 @@
         enabled: true
         state: started
 
-#- name: Ensure docker SDK for Python is present
-#  ansible.builtin.pip:
-#    name: docker
-#  become: true
-
 - name: Create shared docker network
   community.docker.docker_network:
     name: "{{ llm_docker_network }}"

--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Grafana defaults
+
+# Docker image
+grafana_image: "grafana/grafana:latest"
+
+grafana_container_name: "grafana"
+
+expose_grafana_port: "3000"
+
+grafana_data_dir: "/opt/grafana_data"
+
+grafana_admin_user: "admin"
+grafana_admin_password: "admin"

--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -3,12 +3,7 @@
 
 # Docker image
 grafana_image: "grafana/grafana:latest"
-
 grafana_container_name: "grafana"
-
-expose_grafana_port: "3000"
-
 grafana_data_dir: "/opt/grafana_data"
-
 grafana_admin_user: "admin"
 grafana_admin_password: "admin"

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Pull grafana image
+  community.docker.docker_image:
+    name: "{{ grafana_image }}"
+    source: pull
+
+- name: Run grafana
+  community.docker.docker_container:
+    name: grafana
+    image: "{{ grafana_image }}"
+    state: started
+    restart_policy: unless-stopped
+    networks:
+      - name: "{{ llm_docker_network }}"
+    ports:
+      - "{{ expose_grafana_port }}:3000"

--- a/ansible/roles/llm_api/defaults/main.yml
+++ b/ansible/roles/llm_api/defaults/main.yml
@@ -1,9 +1,10 @@
+---
 # ansible/roles/llm_api/defaults/main.yml
-llm_api_image: "YOUR_AWS_ACCOUNT_ID.dkr.ecr.ca-central-1.amazonaws.com/aws-ec2-utils/llm-api-server:latest"
-expose_llm_api_port: "8000"
-ollama_host: "http://ollama:11434"
-openai_api_key: "YOUR_OPENAI_API_KEY_HERE"
+# llm_api_image: ".dkr.ecr.ca-central-1.amazonaws.com/aws-ec2-utils/llm-api-server:latest"
+# expose_llm_api_port: "8000"
+# ollama_host: "http://ollama:11434"
+# openai_api_key: ""
 
 # ECR
-ecr_registry: "YOUR_AWS_ACCOUNT_ID.dkr.ecr.ca-central-1.amazonaws.com"
-ecr_region: "ca-central-1"
+# ecr_registry: ".dkr.ecr.ca-central-1.amazonaws.com"
+# ecr_region: "ca-central-1"

--- a/ansible/roles/llm_api/defaults/main.yml
+++ b/ansible/roles/llm_api/defaults/main.yml
@@ -1,0 +1,9 @@
+# ansible/roles/llm_api/defaults/main.yml
+llm_api_image: "YOUR_AWS_ACCOUNT_ID.dkr.ecr.ca-central-1.amazonaws.com/aws-ec2-utils/llm-api-server:latest"
+expose_llm_api_port: "8000"
+ollama_host: "http://ollama:11434"
+openai_api_key: "YOUR_OPENAI_API_KEY_HERE"
+
+# ECR
+ecr_registry: "YOUR_AWS_ACCOUNT_ID.dkr.ecr.ca-central-1.amazonaws.com"
+ecr_region: "ca-central-1"

--- a/ansible/roles/llm_api/tasks/main.yml
+++ b/ansible/roles/llm_api/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Verify awscli version (should be v2)
   ansible.builtin.command: aws --version
-  register: aws_ver
+  register: llm_api_aws_ver
   changed_when: false
   become: true
 
@@ -36,7 +36,7 @@
   ansible.builtin.command: aws ecr get-login-password --region "{{ ecr_region }}"
   environment:
     AWS_DEFAULT_REGION: "{{ ecr_region }}"
-  register: ecr_pass
+  register: llm_api_ecr_pass
   changed_when: false
   no_log: true
 

--- a/ansible/roles/llm_api/tasks/main.yml
+++ b/ansible/roles/llm_api/tasks/main.yml
@@ -45,9 +45,9 @@
 
 - name: Pull llm-api image from ECR (force refresh even for same tag)
   community.docker.docker_image:
-    name: "{{ llm_api_image }}" # e.g. 5816.../aws-ec2-utils/llm-api-server:latest
+    name: "{{ llm_api_image }}"  # e.g. 5816.../aws-ec2-utils/llm-api-server:latest
     source: pull
-    force_source: true # <- pull even if image already exists
+    force_source: true  # <- pull even if image already exists
   register: llm_api_pull
   become: true
 
@@ -67,8 +67,3 @@
     recreate: "{{ llm_api_pull.changed }}"  # <- only recreate when image actually updated
     pull: false                              # we already pulled above
   become: true
-    # 
-    # log_driver: json-file
-    # log_options:
-    #   max-size: "10m"
-    #   max-file: "3"

--- a/ansible/roles/llm_api/tasks/main.yml
+++ b/ansible/roles/llm_api/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+- name: Ensure deps (curl, unzip) are present
+  ansible.builtin.package:
+    name:
+      - unzip
+    state: present
+  become: true
+
+- name: Download AWS CLI v2 bundle
+  ansible.builtin.get_url:
+    url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+    dest: /tmp/awscliv2.zip
+    mode: '0644'
+  become: true
+
+- name: Unpack AWS CLI v2 bundle
+  ansible.builtin.unarchive:
+    src: /tmp/awscliv2.zip
+    dest: /tmp
+    remote_src: true
+  become: true
+
+- name: Install/Update AWS CLI v2
+  ansible.builtin.command: /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin --update
+  args:
+    creates: /usr/local/bin/aws
+  become: true
+
+- name: Verify awscli version (should be v2)
+  ansible.builtin.command: aws --version
+  register: aws_ver
+  changed_when: false
+  become: true
+
+- name: Login to ECR via AWS CLI v2
+  ansible.builtin.shell: |
+    aws ecr get-login-password --region {{ ecr_region }} \
+    | docker login --username AWS --password-stdin {{ ecr_registry }}
+  args:
+    executable: /bin/bash
+  environment:
+    AWS_DEFAULT_REGION: "{{ ecr_region }}"
+  changed_when: false
+  become: true
+
+- name: Pull llm-api image from ECR (force refresh even for same tag)
+  community.docker.docker_image:
+    name: "{{ llm_api_image }}" # e.g. 5816.../aws-ec2-utils/llm-api-server:latest
+    source: pull
+    force_source: true # <- pull even if image already exists
+  register: llm_api_pull
+  become: true
+
+- name: Run/Recreate llm-api container when image changed
+  community.docker.docker_container:
+    name: llm-api
+    image: "{{ llm_api_image }}"
+    state: started
+    restart_policy: unless-stopped
+    networks:
+      - name: "{{ llm_docker_network }}"
+    ports:
+      - "{{ expose_llm_api_port }}:8000"
+    env:
+      OPENAI_API_KEY: "{{ openai_api_key }}"
+      OLLAMA_HOST: "{{ ollama_host }}"
+    recreate: "{{ llm_api_pull.changed }}"  # <- only recreate when image actually updated
+    pull: false                              # we already pulled above
+  become: true
+    # 
+    # log_driver: json-file
+    # log_options:
+    #   max-size: "10m"
+    #   max-file: "3"

--- a/ansible/roles/llm_api/tasks/main.yml
+++ b/ansible/roles/llm_api/tasks/main.yml
@@ -32,16 +32,21 @@
   changed_when: false
   become: true
 
-- name: Login to ECR via AWS CLI v2
-  ansible.builtin.shell: |
-    aws ecr get-login-password --region {{ ecr_region }} \
-    | docker login --username AWS --password-stdin {{ ecr_registry }}
-  args:
-    executable: /bin/bash
+- name: Get ECR password
+  ansible.builtin.command: aws ecr get-login-password --region "{{ ecr_region }}"
   environment:
     AWS_DEFAULT_REGION: "{{ ecr_region }}"
+  register: ecr_pass
   changed_when: false
+  no_log: true
+
+- name: Docker login to ECR
+  community.docker.docker_login:
+    registry_url: "{{ ecr_registry }}"
+    username: AWS
+    password: "{{ ecr_pass.stdout }}"
   become: true
+  no_log: true
 
 - name: Pull llm-api image from ECR (force refresh even for same tag)
   community.docker.docker_image:

--- a/ansible/roles/ollama/defaults/main.yml
+++ b/ansible/roles/ollama/defaults/main.yml
@@ -1,0 +1,7 @@
+# defaults for ollama role
+ollama_image: "ollama/ollama:latest"
+ollama_container_name: "ollama"
+ollama_port: "11434"
+ollama_network: "{{ llm_docker_network | default('llmnet') }}"
+expose_ollama_port: "11434"
+ollama_volume_dir: "/opt/ollama"

--- a/ansible/roles/ollama/defaults/main.yml
+++ b/ansible/roles/ollama/defaults/main.yml
@@ -1,7 +1,7 @@
+---
 # defaults for ollama role
 ollama_image: "ollama/ollama:latest"
 ollama_container_name: "ollama"
 ollama_port: "11434"
 ollama_network: "{{ llm_docker_network | default('llmnet') }}"
-expose_ollama_port: "11434"
 ollama_volume_dir: "/opt/ollama"

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Pull ollama image
+  community.docker.docker_image:
+    name: "{{ ollama_image }}"
+    source: pull
+
+- name: Run ollama container (persistent model store)
+  community.docker.docker_container:
+    name: ollama
+    image: "{{ ollama_image }}"
+    state: started
+    restart_policy: unless-stopped
+    networks:
+      - name: "{{ llm_docker_network }}"
+    ports:
+      - "{{ expose_ollama_port }}:11434"
+    volumes:
+      - /opt/ollama:/root/.ollama
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+- name: Pull default model for faster first request
+  community.docker.docker_container_exec:
+    container: ollama
+    command: "ollama pull llama3.1:8b"
+  register: pull_result
+  changed_when: "'pulling manifest' in pull_result.stdout or 'downloading' in pull_result.stdout"
+  failed_when: false

--- a/ansible/roles/ollama/tasks/main.yml
+++ b/ansible/roles/ollama/tasks/main.yml
@@ -26,6 +26,6 @@
   community.docker.docker_container_exec:
     container: ollama
     command: "ollama pull llama3.1:8b"
-  register: pull_result
-  changed_when: "'pulling manifest' in pull_result.stdout or 'downloading' in pull_result.stdout"
+  register: ollama_pull_result
+  changed_when: "'pulling manifest' in ollama_pull_result.stdout or 'downloading' in ollama_pull_result.stdout"
   failed_when: false

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -4,6 +4,5 @@
 # Docker image
 prometheus_image: "prom/prometheus:latest"
 prometheus_container_name: "prometheus"
-expose_prometheus_port: "9090"
 prometheus_config_file: "/etc/prometheus/prometheus.yml"
 prometheus_data_dir: "/opt/prometheus_data"

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Prometheus defaults
+
+# Docker image
+prometheus_image: "prom/prometheus:latest"
+prometheus_container_name: "prometheus"
+expose_prometheus_port: "9090"
+prometheus_config_file: "/etc/prometheus/prometheus.yml"
+prometheus_data_dir: "/opt/prometheus_data"

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart prometheus
+  community.docker.docker_container:
+    name: prometheus
+    state: started
+    restart: true

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -9,6 +9,9 @@
         - job_name: "llm-api"
           static_configs:
             - targets: ["llm-api:8000"]
+    owner: root
+    group: root
+    mode: '0644'
   notify: Restart prometheus
 
 - name: Pull prometheus image

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Render prometheus.yml
+  ansible.builtin.copy:
+    dest: /opt/prometheus.yml
+    content: |
+      global:
+        scrape_interval: 5s
+      scrape_configs:
+        - job_name: "llm-api"
+          static_configs:
+            - targets: ["llm-api:8000"]
+  notify: Restart prometheus
+
+- name: Pull prometheus image
+  community.docker.docker_image:
+    name: "{{ prometheus_image }}"
+    source: pull
+
+- name: Run prometheus
+  community.docker.docker_container:
+    name: prometheus
+    image: "{{ prometheus_image }}"
+    state: started
+    restart_policy: unless-stopped
+    networks:
+      - name: "{{ llm_docker_network }}"
+    ports:
+      - "{{ expose_prometheus_port }}:9090"
+    volumes:
+      - /opt/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+# handlers/main.yml
+# - name: Restart prometheus
+#   community.docker.docker_container:
+#     name: prometheus
+#     state: started
+#     restart: true

--- a/llm_server/Dockerfile
+++ b/llm_server/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/llm_server/main.py
+++ b/llm_server/main.py
@@ -1,20 +1,20 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-import httpx
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi.responses import Response
 import time
-import os
 from fastapi import HTTPException
+import os
+import logging
+import httpx
 
 OPENAI_BASE_URL = "https://api.openai.com/v1"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 
-#OLLAMA_API_URL = "http://host.docker.internal:11434/api/generate"
-#OLLAMA_API_URL = "http://localhost:11434/api/generate"
+# OLLAMA_API_URL = "http://host.docker.internal:11434/api/generate"
+# OLLAMA_API_URL = "http://localhost:11434/api/generate"
 
-import os, logging, httpx
 logger = logging.getLogger("uvicorn")
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://ollama:11434")
 OLLAMA_API_URL = f"{OLLAMA_HOST.rstrip('/')}/api/generate"
@@ -68,47 +68,35 @@ async def generate_text(q: Query):
         except httpx.HTTPStatusError as e:
             raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
 
-
     elif q.backend == "openai":
         REQUEST_COUNT.labels(backend=backend).inc()
         start_time = time.time()
 
         headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
         payload = {
-          "model": os.getenv("OPENAI_MODEL","gpt-4o-mini"),
+          "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
           "messages": [
-              {"role": "user", "content": f"{q.prompt.strip()}\n\n{instruction}"}
+              {"role": "user", "content": f"{q.prompt.strip()}\n\n{instruction}"},
           ]
         }
         async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
             res = await client.post(OPENAI_API_URL, headers=headers, json=payload)
 
         if res.status_code >= 400:
-            status = "error"
             raise HTTPException(status_code=res.status_code, detail=res.text[:500])
 
         data = res.json()
         if "error" in data:
-            status = "error"
             raise HTTPException(status_code=502, detail=str(data["error"]))
 
         choices = data.get("choices") or []
         if not choices or "message" not in choices[0]:
-            status = "error"
-            raise HTTPException(status_code=502, detail=f"Unexpected response: keys={list(data.keys())}")
+            raise HTTPException(status_code=502,
+                                detail=f"Unexpected response: keys={list(data.keys())}")
 
         text = choices[0]["message"]["content"]
 
-        #usage = data.get("usage", {})
-        #TOKENS.labels(backend).inc(int(usage.get("completion_tokens", 0)))
-
         return {"output": text}
-            #res.raise_for_status()
-            #response = res.json()
-
-            #duration = time.time() - start_time
-            #REQUEST_LATENCY.labels(backend=backend).observe(duration)
-            #return {"output": response["choices"][0]["message"]["content"]}
 
     else:
         return {"error": "Unsupported backend"}
@@ -118,8 +106,12 @@ async def generate_text(q: Query):
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
+
 @app.get("/health")
-async def health(): return {"ok": True}
+async def health():
+    return {"ok": True}
+
 
 @app.get("/ready")
-async def ready():  return {"ready": True}
+async def ready():
+    return {"ready": True}

--- a/llm_server/main.py
+++ b/llm_server/main.py
@@ -5,10 +5,21 @@ from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_
 from fastapi.responses import Response
 import time
 import os
+from fastapi import HTTPException
 
-OLLAMA_API_URL = "http://localhost:11434/api/generate"
+OPENAI_BASE_URL = "https://api.openai.com/v1"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+
+#OLLAMA_API_URL = "http://host.docker.internal:11434/api/generate"
+#OLLAMA_API_URL = "http://localhost:11434/api/generate"
+
+import os, logging, httpx
+logger = logging.getLogger("uvicorn")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://ollama:11434")
+OLLAMA_API_URL = f"{OLLAMA_HOST.rstrip('/')}/api/generate"
+logger.info(f"OLLAMA_HOST={OLLAMA_HOST} OLLAMA_API_URL={OLLAMA_API_URL}")
+
 
 app = FastAPI()
 
@@ -26,7 +37,7 @@ class Query(BaseModel):
     backend: str = "ollama"
 
 
-@app.post("/generate")
+@app.post("/infer")
 async def generate_text(q: Query):
     backend = getattr(q, "backend", "ollama")  # default if not present
     instruction = "The output answer should be limited to 500 characters."
@@ -34,19 +45,29 @@ async def generate_text(q: Query):
         REQUEST_COUNT.labels(backend=backend).inc()
         start_time = time.time()
 
+        OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.1:8b")
+
         payload = {
-            "model": "llama3.1",
+            "model": OLLAMA_MODEL,
             "prompt": f"{q.prompt.strip()}\n\n{instruction}",
             "stream": False
         }
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-            res = await client.post(OLLAMA_API_URL, json=payload)
-            res.raise_for_status()
-            response = res.json()
-            duration = time.time() - start_time
-            REQUEST_LATENCY.labels(backend=backend).observe(duration)
-            return {"output": response.get("response", "No response")}
+        try:
+
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+                res = await client.post(OLLAMA_API_URL, json=payload)
+                res.raise_for_status()
+                response = res.json()
+                duration = time.time() - start_time
+                REQUEST_LATENCY.labels(backend=backend).observe(duration)
+                return {"output": response.get("response", "No response")}
+
+        except httpx.TimeoutException:
+            raise HTTPException(status_code=504, detail="Upstream timeout")
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
 
     elif q.backend == "openai":
         REQUEST_COUNT.labels(backend=backend).inc()
@@ -54,18 +75,40 @@ async def generate_text(q: Query):
 
         headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
         payload = {
-          "model": "gpt-3.5-turbo",
+          "model": os.getenv("OPENAI_MODEL","gpt-4o-mini"),
           "messages": [
               {"role": "user", "content": f"{q.prompt.strip()}\n\n{instruction}"}
           ]
         }
         async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
             res = await client.post(OPENAI_API_URL, headers=headers, json=payload)
-            res.raise_for_status()
-            response = res.json()
-            duration = time.time() - start_time
-            REQUEST_LATENCY.labels(backend=backend).observe(duration)
-            return {"output": response["choices"][0]["message"]["content"]}
+
+        if res.status_code >= 400:
+            status = "error"
+            raise HTTPException(status_code=res.status_code, detail=res.text[:500])
+
+        data = res.json()
+        if "error" in data:
+            status = "error"
+            raise HTTPException(status_code=502, detail=str(data["error"]))
+
+        choices = data.get("choices") or []
+        if not choices or "message" not in choices[0]:
+            status = "error"
+            raise HTTPException(status_code=502, detail=f"Unexpected response: keys={list(data.keys())}")
+
+        text = choices[0]["message"]["content"]
+
+        #usage = data.get("usage", {})
+        #TOKENS.labels(backend).inc(int(usage.get("completion_tokens", 0)))
+
+        return {"output": text}
+            #res.raise_for_status()
+            #response = res.json()
+
+            #duration = time.time() - start_time
+            #REQUEST_LATENCY.labels(backend=backend).observe(duration)
+            #return {"output": response["choices"][0]["message"]["content"]}
 
     else:
         return {"error": "Unsupported backend"}
@@ -74,3 +117,9 @@ async def generate_text(q: Query):
 @app.get("/metrics")
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+@app.get("/health")
+async def health(): return {"ok": True}
+
+@app.get("/ready")
+async def ready():  return {"ready": True}

--- a/llm_server/requirements.txt
+++ b/llm_server/requirements.txt
@@ -1,0 +1,12 @@
+boto3>=1.26,<2.0
+click>=8.0
+pytest>=7.0
+flake8>=5.0
+moto>=4.0
+pytest-cov>=4.0
+fastapi
+uvicorn
+httpx
+pytest-cov
+prometheus-client
+pydantic

--- a/scripts/gen_inventory.sh
+++ b/scripts/gen_inventory.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-cd ../tofu
+cd ../tofu/ec2
 
 IPS=$(tofu output -json instance_ips | jq -r '.[]')
 
-cd ..
+cd ../..
 
 cat <<EOF > ansible/inventory.ini
 [dev]

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -45,28 +45,40 @@ resource "aws_security_group" "dev_sg" {
   description = "Allow SSH and HTTP inbound"
   vpc_id      = aws_vpc.main.id
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+  ingress { from_port = 22   to_port = 22   protocol = "tcp" cidr_blocks = [var.admin_cidr] }
+  ingress { from_port = 80   to_port = 80   protocol = "tcp" cidr_blocks = ["0.0.0.0/0"] }
+
+  # ----- LLM API (FastAPI 8000) -----
+  dynamic "ingress" {
+    for_each = var.llm_api_cidr //llm_api_cidr = ["0.0.0.0/0"] for opening the Web API to public.
+    content {
+      from_port   = 8000
+      to_port     = 8000
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+      description = "llm-api"
+    }
   }
 
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+  # ----- Prometheus 9090 / Grafana 3000 limiting to my localhost IP-----
+  ingress { from_port = 9090 to_port = 9090 protocol = "tcp" cidr_blocks = [var.admin_cidr] description = "prometheus" }
+  ingress { from_port = 3000 to_port = 3000 protocol = "tcp" cidr_blocks = [var.admin_cidr] description = "grafana" }
+
+  # ----- Ollama 11434 is private and only ECS tasks can access and SG persmission is provided in B
+  # expose_ollama_pub=true
+  dynamic "ingress" {
+    for_each = var.expose_ollama_pub ? [1] : []
+    content {
+      from_port   = 11434
+      to_port     = 11434
+      protocol    = "tcp"
+      cidr_blocks = [var.admin_cidr]
+      description = "ollama (temporary)"
+    }
   }
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # egress 全開
+  egress { from_port = 0 to_port = 0 protocol = "-1" cidr_blocks = ["0.0.0.0/0"] }
 
-  tags = {
-    Name = "${var.name_prefix}-sg"
-  }
+  tags = { Name = "${var.name_prefix}-sg" }
 }

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -17,3 +17,7 @@ variable "name_prefix" {
   type        = string
   description = "Prefix to name VPC resources"
 }
+
+variable "admin_cidr"        { type = string  description = "My localhost IP/32" }
+variable "llm_api_cidr"      { type = list(string) default = ["0.0.0.0/0"] }
+variable "expose_ollama_pub" { type = bool default = false }

--- a/tofu/ec2/main.tf
+++ b/tofu/ec2/main.tf
@@ -4,6 +4,9 @@ module "vpc" {
   public_subnet_cidr = "10.0.1.0/24"
   az                 = "ca-central-1a"
   name_prefix        = "dev"
+  admin_cidr         = var.admin_cidr
+  llm_api_cidr       = var.llm_api_cidr
+  expose_ollama_pub  = var.expose_ollama_pub
 }
 
 module "ec2" {
@@ -67,4 +70,13 @@ provider "aws" {
 
 output "instance_ips" {
   value = module.ec2.instance_ips
+}
+
+data "aws_iam_role" "ec2_role" {
+  name = "CloudWatchEC2"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_readonly" {
+  role       = data.aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }

--- a/tofu/ec2/modules/ec2/main.tf
+++ b/tofu/ec2/modules/ec2/main.tf
@@ -7,15 +7,20 @@ resource "aws_instance" "dev_ec2" {
   vpc_security_group_ids = var.vpc_security_group_ids
   iam_instance_profile   = "CloudWatchEC2"
 
-  user_data = <<-EOF
-    #!/bin/bash
-    yum update -y
-    sudo yum install -y perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https perl-Digest-SHA.x86_64
-    cd /home/ec2-user/
-    curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
-    unzip CloudWatchMonitoringScripts-1.2.2.zip
-    rm -rf CloudWatchMonitoringScripts-1.2.2.zip
-  EOF
+  root_block_device {
+    volume_size = 30
+    delete_on_termination = true
+  }
+
+  #user_data = <<-EOF
+  #  #!/bin/bash
+  #  yum update -y
+  #  sudo yum install -y perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https perl-Digest-SHA.x86_64
+  #  cd /home/ec2-user/
+  #  curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
+  #  unzip CloudWatchMonitoringScripts-1.2.2.zip
+  #  rm -rf CloudWatchMonitoringScripts-1.2.2.zip
+  #EOF
 
   tags = {
     Name          = "dev-server"

--- a/tofu/ec2/modules/vpc/main.tf
+++ b/tofu/ec2/modules/vpc/main.tf
@@ -46,34 +46,68 @@ resource "aws_security_group" "dev_sg" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = [var.admin_cidr]
   }
 
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # ----- LLM API (FastAPI 8000) -----
+  dynamic "ingress" {
+    for_each = var.llm_api_cidr //llm_api_cidr = ["0.0.0.0/0"] for opening the Web API to public.
+    content {
+      from_port   = 8000
+      to_port     = 8000
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+      description = "llm-api"
+    }
+  }
+
+  # ----- Prometheus 9090 / Grafana 3000 limiting to my localhost IP-----
+  ingress {
+    from_port = 9090
+    to_port = 9090
+    protocol = "tcp"
+    cidr_blocks = [var.admin_cidr]
+    description = "prometheus"
   }
 
   ingress {
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port = 3000
+    to_port = 3000
+    protocol = "tcp"
+    cidr_blocks = [var.admin_cidr]
+    description = "grafana"
   }
 
+  # ----- Ollama 11434 is private and only ECS tasks can access and SG persmission is provided in B
+  # expose_ollama_pub=true
+  dynamic "ingress" {
+    for_each = var.expose_ollama_pub ? [1] : []
+    content {
+      from_port   = 11434
+      to_port     = 11434
+      protocol    = "tcp"
+      cidr_blocks = [var.admin_cidr]
+      description = "ollama (temporary)"
+    }
+  }
+
+  # egress open to public.
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    Name = "${var.name_prefix}-sg"
-  }
+  tags = { Name = "${var.name_prefix}-sg" }
 }

--- a/tofu/ec2/modules/vpc/variables.tf
+++ b/tofu/ec2/modules/vpc/variables.tf
@@ -17,3 +17,21 @@ variable "name_prefix" {
   type        = string
   description = "Prefix to name VPC resources"
 }
+
+variable "admin_cidr" {
+  description = "Admin source IP for restricted ports"
+  type        = string
+  default     = "0.0.0.0/0" # Please update this to your IP/32 later.
+}
+
+variable "llm_api_cidr" {
+  description = "CIDR blocks allowed to access the llm-api server (8000)"
+  type        = list(string)
+  default     = ["0.0.0.0/0"] # open to public, but it can be updated to var.admin_cidr
+}
+
+variable "expose_ollama_pub" {
+  description = "Whether to allow external access to Ollama (11434). Default=false"
+  type        = bool
+  default     = false
+}

--- a/tofu/ec2/variables.tf
+++ b/tofu/ec2/variables.tf
@@ -27,7 +27,26 @@ variable "key_name" {
 #  type        = string
 #  description = "SG to attach to EC2"
 #}
+
 variable "instance_count" {
   description = "Number of EC2 instances to launch"
   type        = number
+}
+
+# root variables.tf
+variable "admin_cidr" {
+  description = "Admin source IP (/32) for SSH, Grafana, Prometheus, etc."
+  type        = string
+}
+
+variable "llm_api_cidr" {
+  description = "CIDR blocks allowed to access llm-api (8000)"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "expose_ollama_pub" {
+  description = "Temporarily expose Ollama (11434) to admin_cidr"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
- One-command deployment of a production-ready LLM Inference API on AWS EC2 with full observability (Prometheus/Grafana) and backend switching (Ollama ↔ OpenAI).
- Automated deployment and operation of LLM inference services with reproducible IaC and integrated observability